### PR TITLE
feat: add Serializer and Deserializer

### DIFF
--- a/struct.go
+++ b/struct.go
@@ -22,7 +22,7 @@ var (
 	mTag = regexp.MustCompile(`^\s*(\[([^\]]*)\])?([^\s\(\)]*)(\(([^\)]+)\))?`)
 
 	// single entry of tag-value evaluation
-	mExpression = regexp.MustCompile(`\s*([\+\-])?\s*([^\s\+\-]+)`)
+	mExpression = regexp.MustCompile(`\s*([\+\-\*\/])?\s*([^\s\+\-\*\/]+)`)
 )
 
 // simple add-sub calculator, with struct field referencing
@@ -81,6 +81,10 @@ func evaluateTagValue(strc reflect.Value, stmt string) (value int, err error) {
 			sum = sum + i64
 		case "-":
 			sum = sum - i64
+		case "*":
+			sum = sum * i64
+		case "/":
+			sum = sum / i64
 		default:
 			err = fmt.Errorf("invalid operation <%s>", q.operation)
 			return

--- a/types.go
+++ b/types.go
@@ -130,6 +130,9 @@ type typeOption struct {
 	arrayLen      int    // length of the tagged array
 	bufLen        int    // tagged field is a string or a padding of length bufLen: `binary:"STRINGTYPE(buflen)"`
 	encoding      string // string encoding of the field: `binary:"string,encoding=ENC"`
+
+	deserializer bool
+	serializer   bool
 }
 
 func getITypeFromRType(rt reflect.Type) (it eType) {
@@ -205,6 +208,14 @@ func getNaturalType(v reflect.Value) (t eType, option typeOption) {
 			typ = v.Type()
 			kind = typ.Kind()
 		}
+	}
+
+	if typ.Implements(SerializerType) {
+		option.serializer = true
+	}
+
+	if reflect.PtrTo(typ).Implements(DeserializerType) {
+		option.deserializer = true
 	}
 
 	t = getITypeFromRType(typ)


### PR DESCRIPTION
This is a very good library, but it may not meet the requirements when handling certain data. 

``` go 
// uint24
type Address uint32

func (a Address) Serialize(w io.Writer, order binarystruct.ByteOrder) (int, error) {
	var buf [4]byte
	binary.BigEndian.PutUint32(buf[:], uint32(a)&0xffffff)
	return w.Write(buf[1:])
}

func (a *Address) Deserialize(r io.Reader, order binarystruct.ByteOrder) (n int, err error) {
	var buf [4]byte
	n, err = r.Read(buf[1:])
	if err == nil {
		*a = Address(binary.BigEndian.Uint32(buf[:]) & 0xffffff)
	}
	return
}

var _ binarystruct.Serializer = (*Address)(nil)
var _ binarystruct.Deserializer = (*Address)(nil)
```